### PR TITLE
Add rule explicit-button-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,3 @@ Then configure the rules you want to use under the rules section.
     }
 }
 ```
-
-## Supported Rules
-
-* no-wrap-template-string

--- a/docs/rules/explicit-button-type.md
+++ b/docs/rules/explicit-button-type.md
@@ -1,0 +1,31 @@
+# `<button>` must explicitly has prop `type` (explicit-button-type)
+
+Value of prop `type` of `<button>` can be `submit` or `button` which has different behavior. When a `<button>` does not explicitly has prop `type`, it uses default value, which is `submit`. Most developers don't know about this. As consequence, they unknowingly use submit button when they want to use simple button, and when the button behaves unexpectedly, they tend to fix wrong thing because they don't know the bug's root cause.
+
+## Rule Details
+
+This rule aims to prevent developers from unknowingly use submit button by forcing them to explicitly set `type` of `<button>` so developers will only use submit button when they meant it.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/* eslint hijup/explicit-button-type: "error" */
+
+<button>Do something</button>;
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/* eslint hijup/explicit-button-type: "error" */
+
+<button type="button">Edit</button>;
+```
+
+### Options
+
+This rule does not have any options.
+
+## When Not To Use It
+
+When all developers in your team know about `<button>`'s `type` default value and behavior so you don't need to be helped by this rule.

--- a/lib/rules/explicit-button-type.js
+++ b/lib/rules/explicit-button-type.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Definition of explicit-button-type
+ * @author HIJUP
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "`<button>` must explicitly has prop `type`",
+      category: "React",
+      recommended: true
+    },
+    fixable: null,
+    schema: []
+  },
+
+  create: function(context) {
+    const hasProp = require('jsx-ast-utils/hasProp');
+
+    return {
+
+      JSXOpeningElement(node) {
+        if (!hasProp(node.attributes, 'type')) {
+          context.report({
+            node: node,
+            message: '<button> must explicitly has prop "type"',
+          })
+        }
+      }
+
+    };
+  }
+};

--- a/lib/rules/explicit-button-type.js
+++ b/lib/rules/explicit-button-type.js
@@ -20,12 +20,15 @@ module.exports = {
   },
 
   create: function(context) {
-    const hasProp = require('jsx-ast-utils/hasProp');
+    const jsxUtils = require('jsx-ast-utils');
 
     return {
 
       JSXOpeningElement(node) {
-        if (!hasProp(node.attributes, 'type')) {
+        if (
+          jsxUtils.elementType(node) === 'button' &&
+          !jsxUtils.hasProp(node.attributes, 'type')
+        ) {
           context.report({
             node: node,
             message: '<button> must explicitly has prop "type"',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "mocha tests --recursive"
   },
   "dependencies": {
+    "jsx-ast-utils": "^2.0.1",
     "requireindex": "~1.1.0"
   },
   "peerDependencies": {

--- a/tests/lib/rules/explicit-button-type.js
+++ b/tests/lib/rules/explicit-button-type.js
@@ -38,6 +38,15 @@ ruleTester.run("explicit-button-type", rule, {
       },
       code: '<button type="submit">Save Changes</button>;'
     },
+    {
+      env: { es6: true },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true
+        }
+      },
+      code: '<div>Just text</div>;'
+    },
   ],
 
   invalid: [

--- a/tests/lib/rules/explicit-button-type.js
+++ b/tests/lib/rules/explicit-button-type.js
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Tests for explicit-button-type rule.
+ * @author HIJUP
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/explicit-button-type"),
+    RuleTester = require("eslint").RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("explicit-button-type", rule, {
+
+  valid: [
+    {
+      env: { es6: true },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true
+        }
+      },
+      code: '<button type="button">Edit</button>;'
+    },
+    {
+      env: { es6: true },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true
+        }
+      },
+      code: '<button type="submit">Save Changes</button>;'
+    },
+  ],
+
+  invalid: [
+    {
+      env: { es6: true },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true
+        }
+      },
+      code: '<button>Do something</button>;',
+      errors: [{
+        message: '<button> must explicitly has prop "type"'
+      }]
+    },
+  ]
+});


### PR DESCRIPTION
## TODO

- [x] Perbaiki bug. Seharusnya rule ini hanya mengecek `<button>` :grin: 

## Description

Menambahkan rule ESLint `explicit-button-type` untuk memastikan `<button>` ada `type`-nya sehingga tidak terjadi bug karena developer tidak tahu bahwa by default, `type` nilainya adalah "submit", bukan "button".

## Motivation and Context
Seringkali developer menulis code seperti `<button onClick={changeLanguage}>Pilih bahasa</button>` mengira bahwa tombol tersebut jika diklik hanya akan mengeksekusi `onClick`. Pada kenyataannya, tombol tersebut juga akan men-submit form karena nilai default dari `type` adalah "submit", bukan "button".

Rule ESLint ini untuk mengingatkan developer agar secara eksplisit menuliskan `type="button"` atau `type="submit"` sehingga bisa menghindari bug gara-gara code seperti di atas.

## How Has This Been Tested?
`npm test`

## Screenshots (if appropriate):
N/A

## Types of changes
[ ] Bug fix (non-breaking change which fixes an issue)
[x] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
[x] My code follows the code style of this project.
[x] My change requires a change to the documentation.
[x] I have updated the documentation accordingly.
[x] I have added tests to cover my changes.
[x] All new and existing tests passed.